### PR TITLE
Add styles for all dropdown menu options

### DIFF
--- a/public/css/frdr-theme.css
+++ b/public/css/frdr-theme.css
@@ -546,6 +546,19 @@ fieldset[disabled] .btn-success.active
     display: block;
 }
 
+.dropdown-menu > li > a {
+    color: #333333;
+    text-decoration:  none;
+    font-size: 15px;
+}
+
+.dropdown-menu > li > a:hover, 
+.dropdown-menu > li > a:focus,
+.dropdown-menu > li > a:active {
+    background-color: #2882bb;
+    color: #ffffff;
+}
+
 .dropdown-item {
         padding:0px;
 }
@@ -553,7 +566,7 @@ fieldset[disabled] .btn-success.active
         padding: 0.25rem 1.5rem;
 }
 
-/* End nav styles for all dropdown menus */
+/* End styles for all dropdown menus */
 
 .card-header {
   background-color: rgba(0,0,0,0.08);


### PR DESCRIPTION
This removes the hyperlinks in dropdown menu options and keep the style of all the dropdown menus the same with the navbar dropdown menu.

We have another dropdown menu with such hyperlinks for Get Citation on item landing page. This pull request also fixes that one.